### PR TITLE
Use `a - b` style comparisons rather than `ordering.then(ordering2)` style

### DIFF
--- a/src/comparators.rs
+++ b/src/comparators.rs
@@ -21,16 +21,36 @@ where
     }
 }
 
+// Yes, using this style of comparison instead of `cmp.then(cmp2).then(cmp3)` is
+// actually a big performance win in practice:
+//
+// ```
+// $ cargo benchcmp control variable
+// name                                     control ns/iter  variable ns/iter  diff ns/iter   diff %  speedup
+// bench_parse_part_of_scala_js_source_map  2,029,981        1,290,716         -739,265       -36.42% x 1.57
+// ```
+//
+// This doesn't seem right, but you can't argue with those numbers...
+macro_rules! compare {
+    ($a:expr, $b:expr) => {
+        let cmp = ($a as i64) - ($b as i64);
+        if cmp < 0 {
+            return Ordering::Less;
+        } else if cmp > 0 {
+            return Ordering::Greater;
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct ByGeneratedLocation;
 
 impl ComparatorFunction<Mapping> for ByGeneratedLocation {
     #[inline]
     fn compare(a: &Mapping, b: &Mapping) -> Ordering {
-        a.generated_line
-            .cmp(&b.generated_line)
-            .then(a.generated_column.cmp(&b.generated_column))
-            .then_with(|| ByOriginalLocation::compare(&a.original, &b.original))
+        compare!(a.generated_line, b.generated_line);
+        compare!(a.generated_column, b.generated_column);
+        ByOriginalLocation::compare(&a.original, &b.original)
     }
 }
 
@@ -40,21 +60,24 @@ pub struct ByOriginalLocation;
 impl ComparatorFunction<Mapping> for ByOriginalLocation {
     #[inline]
     fn compare(a: &Mapping, b: &Mapping) -> Ordering {
-        ByOriginalLocation::compare(&a.original, &b.original).then(
-            a.generated_line
-                .cmp(&b.generated_line)
-                .then(a.generated_column.cmp(&b.generated_column)),
-        )
+        let c = ByOriginalLocation::compare(&a.original, &b.original);
+        match c {
+            Ordering::Less | Ordering::Greater => c,
+            Ordering::Equal => {
+                compare!(a.generated_line, b.generated_line);
+                compare!(a.generated_column, b.generated_column);
+                Ordering::Equal
+            }
+        }
     }
 }
 
 impl ComparatorFunction<OriginalLocation> for ByOriginalLocation {
     #[inline]
     fn compare(a: &OriginalLocation, b: &OriginalLocation) -> Ordering {
-        a.source
-            .cmp(&b.source)
-            .then(a.original_line.cmp(&b.original_line))
-            .then(a.original_column.cmp(&b.original_column))
-            .then(a.name.cmp(&b.name))
+        compare!(a.source, b.source);
+        compare!(a.original_line, b.original_line);
+        compare!(a.original_column, b.original_column);
+        a.name.cmp(&b.name)
     }
 }


### PR DESCRIPTION
Yes, using this style of comparison is actually a big performance win in
practice:

```
$ cargo benchcmp control variable
name                                     control ns/iter  variable ns/iter  diff ns/iter   diff %  speedup
bench_parse_part_of_scala_js_source_map  2,029,981        1,290,716         -739,265       -36.42% x 1.57
```

This doesn't seem right, but you can't argue with those numbers...

cc @tromey 