### PR TITLE
Our bench should use the same source and line number that mozilla/sou…

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,6 +9,7 @@ static FIXTURE: &'static [u8] = include_bytes!("./part-of-scala-js-source-map");
 fn bench_parse_part_of_scala_js_source_map(b: &mut test::Bencher) {
     b.iter(|| {
         let mut mappings = source_map_mappings::parse_mappings::<()>(FIXTURE).unwrap();
-        test::black_box(mappings.all_generated_locations_for(0, 0, None).count());
+        // mozilla/source-map's bench.js's TEST_MAPPING's source and line number.
+        test::black_box(mappings.all_generated_locations_for(149, 32994, None).count());
     });
 }


### PR DESCRIPTION
…rce-map's bench uses