### PR TITLE
Use the same quick sort that mozilla/source-map does

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,19 @@
 [package]
-authors = ["Nick Fitzgerald <fitzgen@gmail.com>", "Tom Tromey <tom@tromey.com>"]
-categories = ["development-tools::debugging", "parser-implementations"]
+authors = [
+    "Nick Fitzgerald <fitzgen@gmail.com>",
+    "Tom Tromey <tom@tromey.com>",
+]
+categories = [
+    "development-tools::debugging",
+    "parser-implementations",
+]
 description = "Parse the `mappings` string from a source map."
-keywords = ["sourcemap", "source", "map", "vlq"]
+keywords = [
+    "sourcemap",
+    "source",
+    "map",
+    "vlq",
+]
 license = "Apache-2.0/MIT"
 name = "source-map-mappings"
 readme = "./README.md"
@@ -13,10 +24,10 @@ version = "0.2.0"
 repository = "fitzgen/source-map-mappings"
 
 [dependencies]
+rand = "0.4.1"
 vlq = "0.5"
 
 [dev-dependencies]
 quickcheck = "0.5.0"
-
 [profile.release]
 debug = true

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,7 +9,10 @@ static FIXTURE: &'static [u8] = include_bytes!("./part-of-scala-js-source-map");
 fn bench_parse_part_of_scala_js_source_map(b: &mut test::Bencher) {
     b.iter(|| {
         let mut mappings = source_map_mappings::parse_mappings::<()>(FIXTURE).unwrap();
-        // mozilla/source-map's bench.js's TEST_MAPPING's source and line number.
-        test::black_box(mappings.all_generated_locations_for(149, 32994, None).count());
+        test::black_box(
+            mappings
+                .all_generated_locations_for(7, 2, None)
+                .count(),
+        );
     });
 }

--- a/source-map-mappings-wasm-api/src/lib.rs
+++ b/source-map-mappings-wasm-api/src/lib.rs
@@ -140,8 +140,6 @@ fn assert_pointer_is_word_aligned(p: *mut u8) {
     assert_eq!(p as usize & (mem::size_of::<usize>() - 1), 0);
 }
 
-// TODO: factor out allocation into its own wasm-allocator crate.
-
 /// Allocate space for a mappings string of the given size (in bytes).
 ///
 /// It is the JS callers responsibility to initialize the resulting buffer by

--- a/src/comparators.rs
+++ b/src/comparators.rs
@@ -1,8 +1,12 @@
+//! Comparator functions for sorting mappings in different ways.
+
 use super::{Mapping, OriginalLocation};
 use std::cmp::Ordering;
 use std::fmt;
 
+/// A function that can compare two `T`s.
 pub trait ComparatorFunction<T>: fmt::Debug {
+    /// Compare the given values.
     fn compare(&T, &T) -> Ordering;
 }
 
@@ -42,6 +46,8 @@ macro_rules! compare {
     }
 }
 
+/// Sort mappings by their generated locations, breaking ties by their original
+/// locations.
 #[derive(Debug)]
 pub struct ByGeneratedLocation;
 
@@ -54,6 +60,8 @@ impl ComparatorFunction<Mapping> for ByGeneratedLocation {
     }
 }
 
+/// Sort mappings by their original locations, breaking ties by their generated
+/// locations.
 #[derive(Debug)]
 pub struct ByOriginalLocation;
 

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,0 +1,89 @@
+//! Custom quick sort implementation that is fast for sorting mappings.
+
+use comparators::ComparatorFunction;
+use rand::{self, Rng};
+use std::cmp::{self, Ordering};
+use std::mem;
+
+/// Swap the elements in `slice` at indices `x` and `y`.
+///
+/// For whatever reason, this ends up being an order of magnitude faster than
+/// using the builtin `slice::swap` -- maybe because we can't force that to be
+/// inlined?
+#[inline(always)]
+fn swap<T>(slice: &mut [T], x: usize, y: usize) {
+    debug_assert!(x < slice.len(), "(x = {}) < (slice.len() = {})", x, slice.len());
+    debug_assert!(y < slice.len(), "(y = {}) < (slice.len() = {})", y, slice.len());
+
+    if x == y {
+        return;
+    }
+
+    let (x, y) = (cmp::min(x, y), cmp::max(x, y));
+    let (low, high) = slice.split_at_mut(y);
+
+    debug_assert!(x < low.len());
+    debug_assert!(0 < high.len());
+
+    unsafe {
+        mem::swap(low.get_unchecked_mut(x), high.get_unchecked_mut(0));
+    }
+}
+
+/// Partition the `slice[p..r]` about some pivot element in that range, and
+/// return the index of the pivot.
+#[inline(always)]
+fn partition<R, F, T>(rng: &mut R, slice: &mut [T], p: usize, r: usize) -> usize
+where
+    R: Rng,
+    F: ComparatorFunction<T>
+{
+    let pivot = rng.gen_range(p, r + 1);
+    swap(slice, pivot, r);
+
+    let mut i = (p as isize) - 1;
+
+    for j in p..r {
+        if let Ordering::Greater = unsafe {
+            debug_assert!(j < slice.len());
+            debug_assert!(r < slice.len());
+            F::compare(slice.get_unchecked(j), slice.get_unchecked(r))
+        } {
+            continue;
+        }
+
+        i += 1;
+        swap(slice, i as usize, j);
+    }
+
+    swap(slice, (i + 1) as usize, r);
+    return (i + 1) as usize;
+}
+
+/// Recursive quick sort implementation with all the extra parameters that we
+/// want to hide from callers to give them better ergonomics.
+fn do_quick_sort<R, F, T>(rng: &mut R, slice: &mut [T], p: usize, r: usize)
+where
+    R: Rng,
+    F: ComparatorFunction<T>
+{
+    if p < r {
+        let q = partition::<R, F, T>(rng, slice, p, r);
+        do_quick_sort::<R, F, T>(rng, slice, p, q.saturating_sub(1));
+        do_quick_sort::<R, F, T>(rng, slice, q + 1, r);
+    }
+}
+
+/// Do a quick sort on the given slice.
+pub fn quick_sort<F, T>(slice: &mut [T])
+where
+    F: ComparatorFunction<T>
+{
+    if slice.is_empty() {
+        return;
+    }
+
+    let mut rng = rand::XorShiftRng::new_unseeded();
+    let len = slice.len();
+    do_quick_sort::<_, F, T>(&mut rng, slice, 0, len - 1);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,6 @@
 extern crate source_map_mappings;
 
-use source_map_mappings::{Bias, Mapping, Mappings, OriginalLocation, parse_mappings};
+use source_map_mappings::{parse_mappings, Bias, Mapping, Mappings, OriginalLocation};
 
 #[test]
 fn parse_empty_mappings() {
@@ -46,10 +46,7 @@ fn assert_original_location_for(
     assert_eq!(actual, expected.as_ref());
 }
 
-fn assert_bidirectional(
-    mappings: &mut Mappings,
-    mapping: Mapping,
-) {
+fn assert_bidirectional(mappings: &mut Mappings, mapping: Mapping) {
     let orig = mapping.original.as_ref().unwrap();
     for bias in &[Bias::GreatestLowerBound, Bias::LeastUpperBound] {
         assert_generated_location_for(
@@ -58,7 +55,7 @@ fn assert_bidirectional(
             orig.original_line,
             orig.original_column,
             *bias,
-            Some(mapping.clone())
+            Some(mapping.clone()),
         );
 
         assert_original_location_for(
@@ -66,7 +63,7 @@ fn assert_bidirectional(
             mapping.generated_line,
             mapping.generated_column,
             *bias,
-            Some(mapping.clone())
+            Some(mapping.clone()),
         );
     }
 }
@@ -85,9 +82,9 @@ fn test_mapping_back_exactly() {
                 source: 0,
                 original_line: 0,
                 original_column: 1,
-                name: None
-            })
-        }
+                name: None,
+            }),
+        },
     );
     assert_bidirectional(
         &mut mappings,
@@ -100,8 +97,8 @@ fn test_mapping_back_exactly() {
                 original_line: 0,
                 original_column: 5,
                 name: None,
-            })
-        }
+            }),
+        },
     );
     assert_bidirectional(
         &mut mappings,
@@ -114,8 +111,8 @@ fn test_mapping_back_exactly() {
                 original_line: 0,
                 original_column: 11,
                 name: None,
-            })
-        }
+            }),
+        },
     );
     assert_bidirectional(
         &mut mappings,
@@ -128,8 +125,8 @@ fn test_mapping_back_exactly() {
                 original_line: 0,
                 original_column: 21,
                 name: Some(0),
-            })
-        }
+            }),
+        },
     );
     assert_bidirectional(
         &mut mappings,
@@ -142,8 +139,8 @@ fn test_mapping_back_exactly() {
                 original_line: 1,
                 original_column: 3,
                 name: None,
-            })
-        }
+            }),
+        },
     );
     assert_bidirectional(
         &mut mappings,
@@ -156,8 +153,8 @@ fn test_mapping_back_exactly() {
                 original_line: 1,
                 original_column: 10,
                 name: Some(1),
-            })
-        }
+            }),
+        },
     );
     assert_bidirectional(
         &mut mappings,
@@ -170,8 +167,8 @@ fn test_mapping_back_exactly() {
                 original_line: 1,
                 original_column: 14,
                 name: Some(0),
-            })
-        }
+            }),
+        },
     );
 
     assert_bidirectional(
@@ -185,8 +182,8 @@ fn test_mapping_back_exactly() {
                 original_line: 0,
                 original_column: 1,
                 name: None,
-            })
-        }
+            }),
+        },
     );
     assert_bidirectional(
         &mut mappings,
@@ -199,8 +196,8 @@ fn test_mapping_back_exactly() {
                 original_line: 0,
                 original_column: 5,
                 name: None,
-            })
-        }
+            }),
+        },
     );
     assert_bidirectional(
         &mut mappings,
@@ -213,8 +210,8 @@ fn test_mapping_back_exactly() {
                 original_line: 0,
                 original_column: 11,
                 name: None,
-            })
-        }
+            }),
+        },
     );
     assert_bidirectional(
         &mut mappings,
@@ -227,8 +224,8 @@ fn test_mapping_back_exactly() {
                 original_line: 0,
                 original_column: 21,
                 name: Some(2),
-            })
-        }
+            }),
+        },
     );
     assert_bidirectional(
         &mut mappings,
@@ -241,8 +238,8 @@ fn test_mapping_back_exactly() {
                 original_line: 1,
                 original_column: 3,
                 name: None,
-            })
-        }
+            }),
+        },
     );
     assert_bidirectional(
         &mut mappings,
@@ -255,8 +252,8 @@ fn test_mapping_back_exactly() {
                 original_line: 1,
                 original_column: 10,
                 name: Some(2),
-            })
-        }
+            }),
+        },
     );
 }
 
@@ -285,7 +282,7 @@ fn test_all_generated_locations_for_some_line() {
                     original_line: 1,
                     original_column: 1,
                     name: None,
-                })
+                }),
             },
             Mapping {
                 generated_line: 2,
@@ -296,7 +293,7 @@ fn test_all_generated_locations_for_some_line() {
                     original_line: 1,
                     original_column: 2,
                     name: None,
-                })
+                }),
             },
         ]
     );
@@ -326,9 +323,9 @@ fn test_all_generated_locations_for_line_fuzzy() {
                     source: 1,
                     original_line: 2,
                     original_column: 1,
-                    name: None
-                })
-            }
+                    name: None,
+                }),
+            },
         ]
     );
 }
@@ -357,8 +354,8 @@ fn test_all_generated_locations_for_column() {
                     source: 0,
                     original_line: 0,
                     original_column: 1,
-                    name: None
-                })
+                    name: None,
+                }),
             },
             Mapping {
                 generated_line: 0,
@@ -368,9 +365,9 @@ fn test_all_generated_locations_for_column() {
                     source: 0,
                     original_line: 0,
                     original_column: 1,
-                    name: None
-                })
-            }
+                    name: None,
+                }),
+            },
         ]
     );
 }
@@ -395,8 +392,8 @@ fn test_all_generated_locations_for_column_fuzzy() {
                     source: 0,
                     original_line: 0,
                     original_column: 1,
-                    name: None
-                })
+                    name: None,
+                }),
             },
             Mapping {
                 generated_line: 0,
@@ -406,9 +403,9 @@ fn test_all_generated_locations_for_column_fuzzy() {
                     source: 0,
                     original_line: 0,
                     original_column: 1,
-                    name: None
-                })
-            }
+                    name: None,
+                }),
+            },
         ]
     );
 }


### PR DESCRIPTION
This is a bit finnicky, which is a bit worrying. Using `slice::swap` instead of this version results in a couple orders of magnitude slow down, as does using any kind of pointer swapping. I think it ends up defeating some bounds check elimination in the wasm engines, because the `#[bench]`es don't produce the same result, just the bench.html with wasm.